### PR TITLE
Fixes issue #4 Expose `verify` option

### DIFF
--- a/pynxos/device.py
+++ b/pynxos/device.py
@@ -13,14 +13,15 @@ class RebootSignal(NXOSError):
 
 
 class Device(object):
-    def __init__(self, host, username, password, transport=u'http', port=None, timeout=30):
+    def __init__(self, host, username, password, transport=u'http', port=None, timeout=30, verify=True):
         self.host = host
         self.username = username
         self.password = password
         self.transport = transport
         self.timeout = timeout
+        self.verify = verify
 
-        self.rpc = RPCClient(host, username, password, transport=transport, port=port)
+        self.rpc = RPCClient(host, username, password, transport=transport, port=port, verify=self.verify)
 
     def _cli_error_check(self, command_response):
         error = command_response.get(u'error')

--- a/pynxos/lib/rpc_client.py
+++ b/pynxos/lib/rpc_client.py
@@ -8,7 +8,7 @@ from pynxos.errors import NXOSError
 # requests.packages.urllib3.disable_warnings()
 
 class RPCClient(object):
-    def __init__(self, host, username, password, transport=u'http', port=None):
+    def __init__(self, host, username, password, transport=u'http', port=None, verify=True):
         if transport not in ['http', 'https']:
             raise NXOSError('\'%s\' is an invalid transport.' % transport)
 
@@ -22,6 +22,7 @@ class RPCClient(object):
         self.headers = {u'content-type': u'application/json-rpc'}
         self.username = username
         self.password = password
+        self.verify = verify
 
     def _build_payload(self, commands, method, rpc_version=u'2.0'):
         payload_list = []
@@ -46,7 +47,7 @@ class RPCClient(object):
                                  data=json.dumps(payload_list),
                                  headers=self.headers,
                                  auth=HTTPBasicAuth(self.username, self.password),
-                                 verify=False)
+                                 verify=self.verify)
 
         response_list = json.loads(response.text)
 


### PR DESCRIPTION
`requests` enforces proper SSL etiquette by verifying the certificate. By setting this to `False`, security is compromised. Instead, I propose exposing the option, and setting it to `True` by default.