### PR TITLE
Ability to issue show commands via XML for NXAPI

### DIFF
--- a/pynxos/device.py
+++ b/pynxos/device.py
@@ -1,6 +1,7 @@
 import signal
 import re
 from .lib.rpc_client import RPCClient
+from .lib.xml_client import XMLClient
 from .lib import convert_dict_by_key, converted_list_from_table, strip_unicode
 from .lib.data_model import key_maps
 from pynxos.features.file_copy import FileCopy
@@ -21,6 +22,7 @@ class Device(object):
         self.timeout = timeout
 
         self.rpc = RPCClient(host, username, password, transport=transport, port=port)
+        self.xml = XMLClient(host, username, password, transport=transport, port=port)
 
     def _cli_error_check(self, command_response):
         error = command_response.get(u'error')
@@ -30,6 +32,14 @@ class Device(object):
                 raise CLIError(command, error[u'data'][u'msg'])
             else:
                 raise CLIError(command, 'Invalid command.')
+
+    def _cli_command_xml(self, commands, method=u'cli_show'):
+        if not isinstance(commands, list):
+            commands = [commands]
+
+        xml_response = self.xml.send_request(commands, method=method, timeout=self.timeout)
+
+        print xml_response
 
     def _cli_command(self, commands, method=u'cli'):
         if not isinstance(commands, list):

--- a/pynxos/lib/xml_client.py
+++ b/pynxos/lib/xml_client.py
@@ -1,0 +1,65 @@
+import requests
+from requests.auth import HTTPBasicAuth
+import json
+
+from builtins import range
+from pynxos.errors import NXOSError
+import xmltodict
+
+# requests.packages.urllib3.disable_warnings()
+
+
+class XMLClient(object):
+    def __init__(self, host, username, password, transport=u'http', port=None):
+        if transport not in ['http', 'https']:
+            raise NXOSError('\'%s\' is an invalid transport.' % transport)
+
+        if port is None:
+            if transport == 'http':
+                port = 80
+            elif transport == 'https':
+                port = 443
+
+        self.url = u'%s://%s:%s/ins' % (transport, host, port)
+        self.headers = {u'content-type': u'application/xml'}
+        self.username = username
+        self.password = password
+
+    def _build_payload(self, commands, method, xml_version=u'1.0'):
+
+        if len(commands) > 1:
+            command = 0
+            for item in commands:
+                if command == 0:
+                    command = item
+                else:
+                    command = '{}{}{}'.format(command, ' ;', item)
+        else:
+            command = commands[0]
+
+        payload = """<?xml version="{}"?>
+            <ins_api>
+                <version>{}</version>
+                <type>{}</type>
+                <chunk>0</chunk>
+                <sid>sid</sid>
+                <input>{}</input>
+                <output_format>xml</output_format>
+            </ins_api>""".format(xml_version, xml_version, method, command)
+
+        return payload
+
+    def send_request(self, commands, method=u'cli_show', timeout=30):
+        timeout = int(timeout)
+        payload = self._build_payload(commands, method)
+
+        response = requests.post(self.url,
+                                 timeout=timeout,
+                                 data=payload,
+                                 headers=self.headers,
+                                 auth=HTTPBasicAuth(self.username, self.password),
+                                 verify=False)
+
+        response = response.text
+
+        return response


### PR DESCRIPTION
This PR comes from a need to implement XML based returns for NXAPI vs JSON.

Reference:
https://github.com/napalm-automation/napalm/pull/578

This specification comes from the cumbersome amount of bugs when Cisco converts XML to JSON. 

This PR is far from complete but wanted to show an example of how this is done. The `def _cli_command_xml(self, commands, method=u'cli_show'):` function will return straight `XML` with no parsing abilities. 